### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 urllib3
 requests
-sys
-time
 colorama


### PR DESCRIPTION
sys and time are default libraries that come with python. Adding this in the requirement.txt file will throw the error.(404)
Removing these modules for better "prerequisites installation" of the script.
Hope that helps! :)
Thanks